### PR TITLE
[ENH] Add Fast View mode for improved performance with large USD files

### DIFF
--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -374,6 +374,7 @@ a.binary {{color:#69F}}
         textEdit = icon("accessories-text-editor")
         self.actionEdit.setIcon(textEdit)
         self.actionTextEditor.setIcon(textEdit)
+        self.actionRawView.setIcon(textEdit)
         self.buttonGo.setIcon(icon("media-playback-start"))
         self.actionFullScreen.setIcon(icon("view-fullscreen"))
         self.browserReloadIcon = icon("view-refresh")
@@ -727,7 +728,7 @@ a.binary {{color:#69F}}
         default = self.app.DEFAULTS
         self.preferences = {
             'parseLinks': self.config.boolValue("parseLinks", default['parseLinks']),
-            'fastViewDefault': self.config.boolValue("fastViewDefault", default['fastViewDefault']),
+            'rawViewDefault': self.config.boolValue("rawViewDefault", default['rawViewDefault']),
             'newTab': self.config.boolValue("newTab", default['newTab']),
             'syntaxHighlighting': self.config.boolValue("syntaxHighlighting", default['syntaxHighlighting']),
             'teletype': self.config.boolValue("teletype", default['teletype']),
@@ -810,7 +811,7 @@ a.binary {{color:#69F}}
         """
         logger.debug("Writing user settings to %s", self.config.fileName())
         self.config.setValue("parseLinks", self.preferences['parseLinks'])
-        self.config.setValue("fastViewDefault", self.preferences['fastViewDefault'])
+        self.config.setValue("rawViewDefault", self.preferences['rawViewDefault'])
         self.config.setValue("newTab", self.preferences['newTab'])
         self.config.setValue("syntaxHighlighting", self.preferences['syntaxHighlighting'])
         self.config.setValue("teletype", self.preferences['teletype'])
@@ -909,7 +910,7 @@ a.binary {{color:#69F}}
         # Edit Menu
         self.actionEdit.triggered.connect(self.toggleEdit)
         self.actionBrowse.triggered.connect(self.toggleEdit)
-        self.actionFastView.triggered.connect(self.toggleFastView)
+        self.actionRawView.triggered.connect(self.toggleRawView)
         self.actionUndo.triggered.connect(self.undo)
         self.actionRedo.triggered.connect(self.redo)
         self.actionCut.triggered.connect(self.cut)
@@ -1716,14 +1717,14 @@ a.binary {{color:#69F}}
         return True
 
     @Slot()
-    def toggleFastView(self, checked=False, tab=None):
-        """ Switch between normal Browse mode and Fast View mode.
+    def toggleRawView(self, checked=False, tab=None):
+        """ Switch between normal Browse mode and Raw View mode.
 
         :Parameters:
             checked : `bool`
                 Unused. For signal/slot only
             tab : `BrowserTab`
-                Tab to toggle fast view mode on
+                Tab to toggle raw view mode on
         :Returns:
             True if we switched modes; otherwise, False.
         :Rtype:
@@ -1733,12 +1734,12 @@ a.binary {{color:#69F}}
         if not tab:
             return False
 
-        # Don't allow fast view in edit mode
+        # Don't allow raw view in edit mode
         if tab.inEditMode:
             return False
 
-        # Toggle fast view mode
-        tab.inFastView = not tab.inFastView
+        # Toggle raw view mode
+        tab.inRawView = not tab.inRawView
         
         # Refresh the tab to apply the new parsing mode
         self.refreshTab(tab=tab)
@@ -3086,7 +3087,7 @@ a.binary {{color:#69F}}
                         # Stop Loading Tab stops the expensive parsing of the file
                         # for links, checking if the links actually exist, etc.
                         # Setting it to this bypasses link parsing if the tab is in edit mode.
-                        parser.stop(tab.inEditMode or getattr(tab, 'inFastView', False) or not self.preferences['parseLinks'])
+                        parser.stop(tab.inEditMode or getattr(tab, 'inRawView', False) or not self.preferences['parseLinks'])
                         self.actionStop.setEnabled(True)
 
                         parser.parse(nativeAbsPath, fileInfo, link)
@@ -3440,6 +3441,8 @@ a.binary {{color:#69F}}
             self.actionUncomment.setEnabled(True)
             self.actionIndent.setEnabled(True)
             self.actionUnindent.setEnabled(True)
+            self.actionRawView.setEnabled(False)
+            self.actionRawView.setText("Raw View")
         else:
             self.actionEdit.setVisible(True)
             self.actionBrowse.setVisible(False)
@@ -3454,6 +3457,8 @@ a.binary {{color:#69F}}
             self.actionUncomment.setEnabled(False)
             self.actionIndent.setEnabled(False)
             self.actionUnindent.setEnabled(False)
+            self.actionRawView.setEnabled(True)
+            self.actionRawView.setText("Raw View" if not self.currTab.inRawView else "Disable Raw View")
 
     @Slot(str)
     def validateAddressBar(self, address):
@@ -4375,7 +4380,7 @@ class BrowserTab(QtWidgets.QWidget):
             color = self.style().standardPalette().base().color().darker(105).name()
         self.setStyleSheet("QTextBrowser{{background-color:{}}}".format(color))
         self.inEditMode = False
-        self.inFastView = parent.window().preferences.get('fastViewDefault', False) if parent else False
+        self.inRawView = parent.window().preferences.get('rawViewDefault', False) if parent else False
         self.isActive = True  # Track if this tab is open or has been closed.
         self.isNewTab = True  # Track if this tab has been used for any files yet.
         self.setAcceptDrops(True)
@@ -4890,7 +4895,7 @@ class App(QtCore.QObject):
             'lineNumbers': True,
             'newTab': False,
             'parseLinks': True,
-            'fastViewDefault': False,
+            'rawViewDefault': False,
             'showAllMessages': True,
             'showHiddenFiles': False,
             'syntaxHighlighting': True,

--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -600,6 +600,10 @@ a.binary {{color:#69F}}
             logger.debug("Setting highlighter to %s", ext)
             tab.highlighter.deleteLater()
             tab.highlighter = highlighter.Highlighter(tab.getCurrentTextWidget().document(), master)
+        
+        # Disable syntax highlighting if in Raw View mode
+        enableHighlighting = self.preferences['syntaxHighlighting'] and not getattr(tab, 'inRawView', False)
+        tab.highlighter.master.setSyntaxHighlighting(enableHighlighting)
 
     @Slot(QtCore.QPoint)
     def customTextBrowserContextMenu(self, pos):
@@ -1740,6 +1744,11 @@ a.binary {{color:#69F}}
 
         # Toggle raw view mode
         tab.inRawView = not tab.inRawView
+        
+        # Update syntax highlighting immediately without full refresh
+        enableHighlighting = self.preferences['syntaxHighlighting'] and not tab.inRawView
+        if hasattr(tab, 'highlighter') and tab.highlighter:
+            tab.highlighter.master.setSyntaxHighlighting(enableHighlighting)
         
         # Refresh the tab to apply the new parsing mode
         self.refreshTab(tab=tab)

--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -538,6 +538,9 @@ a.binary {{color:#69F}}
         # Add one of our special tabs.
         self.currTab = self.newTab()
         self.setNavigationMenus()
+        
+        # Ensure UI reflects initial tab state (e.g., Raw View button text)
+        self.updateEditButtons()
 
         # Adjust tab order.
         self.setTabOrder(self.addressBar, self.includeWidget.listView)
@@ -1752,6 +1755,11 @@ a.binary {{color:#69F}}
         
         # Refresh the tab to apply the new parsing mode
         self.refreshTab(tab=tab)
+        
+        # Ensure UI buttons are updated even if refreshTab() returns early (e.g., for empty tabs)
+        if tab == self.currTab:
+            self.updateEditButtons()
+        
         return True
 
     @Slot()
@@ -2238,6 +2246,7 @@ a.binary {{color:#69F}}
             self.preferences['newTab'] = dlg.getPrefNewTab()
             self.preferences['lineNumbers'] = dlg.getPrefLineNumbers()
             self.preferences['showAllMessages'] = dlg.getPrefShowAllMessages()
+            self.preferences['rawViewDefault'] = dlg.getPrefRawViewDefault()
             self.preferences['showHiddenFiles'] = dlg.getPrefShowHiddenFiles()
             self.preferences['autoCompleteAddressBar'] = dlg.getPrefAutoCompleteAddressBar()
             self.preferences['textEditor'] = dlg.getPrefTextEditor()

--- a/usdmanager/__init__.py
+++ b/usdmanager/__init__.py
@@ -727,6 +727,7 @@ a.binary {{color:#69F}}
         default = self.app.DEFAULTS
         self.preferences = {
             'parseLinks': self.config.boolValue("parseLinks", default['parseLinks']),
+            'fastViewDefault': self.config.boolValue("fastViewDefault", default['fastViewDefault']),
             'newTab': self.config.boolValue("newTab", default['newTab']),
             'syntaxHighlighting': self.config.boolValue("syntaxHighlighting", default['syntaxHighlighting']),
             'teletype': self.config.boolValue("teletype", default['teletype']),
@@ -809,6 +810,7 @@ a.binary {{color:#69F}}
         """
         logger.debug("Writing user settings to %s", self.config.fileName())
         self.config.setValue("parseLinks", self.preferences['parseLinks'])
+        self.config.setValue("fastViewDefault", self.preferences['fastViewDefault'])
         self.config.setValue("newTab", self.preferences['newTab'])
         self.config.setValue("syntaxHighlighting", self.preferences['syntaxHighlighting'])
         self.config.setValue("teletype", self.preferences['teletype'])
@@ -907,6 +909,7 @@ a.binary {{color:#69F}}
         # Edit Menu
         self.actionEdit.triggered.connect(self.toggleEdit)
         self.actionBrowse.triggered.connect(self.toggleEdit)
+        self.actionFastView.triggered.connect(self.toggleFastView)
         self.actionUndo.triggered.connect(self.undo)
         self.actionRedo.triggered.connect(self.redo)
         self.actionCut.triggered.connect(self.cut)
@@ -1710,6 +1713,35 @@ a.binary {{color:#69F}}
         self.findRehighlightAll()
         if tab == self.currTab:
             self.editModeChanged.emit(tab.inEditMode)
+        return True
+
+    @Slot()
+    def toggleFastView(self, checked=False, tab=None):
+        """ Switch between normal Browse mode and Fast View mode.
+
+        :Parameters:
+            checked : `bool`
+                Unused. For signal/slot only
+            tab : `BrowserTab`
+                Tab to toggle fast view mode on
+        :Returns:
+            True if we switched modes; otherwise, False.
+        :Rtype:
+            `bool`
+        """
+        tab = tab or self.currTab
+        if not tab:
+            return False
+
+        # Don't allow fast view in edit mode
+        if tab.inEditMode:
+            return False
+
+        # Toggle fast view mode
+        tab.inFastView = not tab.inFastView
+        
+        # Refresh the tab to apply the new parsing mode
+        self.refreshTab(tab=tab)
         return True
 
     @Slot()
@@ -3054,7 +3086,7 @@ a.binary {{color:#69F}}
                         # Stop Loading Tab stops the expensive parsing of the file
                         # for links, checking if the links actually exist, etc.
                         # Setting it to this bypasses link parsing if the tab is in edit mode.
-                        parser.stop(tab.inEditMode or not self.preferences['parseLinks'])
+                        parser.stop(tab.inEditMode or getattr(tab, 'inFastView', False) or not self.preferences['parseLinks'])
                         self.actionStop.setEnabled(True)
 
                         parser.parse(nativeAbsPath, fileInfo, link)
@@ -4343,6 +4375,7 @@ class BrowserTab(QtWidgets.QWidget):
             color = self.style().standardPalette().base().color().darker(105).name()
         self.setStyleSheet("QTextBrowser{{background-color:{}}}".format(color))
         self.inEditMode = False
+        self.inFastView = parent.window().preferences.get('fastViewDefault', False) if parent else False
         self.isActive = True  # Track if this tab is open or has been closed.
         self.isNewTab = True  # Track if this tab has been used for any files yet.
         self.setAcceptDrops(True)
@@ -4857,6 +4890,7 @@ class App(QtCore.QObject):
             'lineNumbers': True,
             'newTab': False,
             'parseLinks': True,
+            'fastViewDefault': False,
             'showAllMessages': True,
             'showHiddenFiles': False,
             'syntaxHighlighting': True,

--- a/usdmanager/main_window.ui
+++ b/usdmanager/main_window.ui
@@ -589,6 +589,7 @@
    <addaction name="separator"/>
    <addaction name="actionBrowse"/>
    <addaction name="actionEdit"/>
+   <addaction name="actionFastView"/>
   </widget>
   <widget class="QToolBar" name="navToolbar">
    <property name="windowTitle">
@@ -1031,6 +1032,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+E</string>
+   </property>
+  </action>
+  <action name="actionFastView">
+   <property name="icon">
+    <iconset theme="view-refresh">
+     <normaloff/>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Fast View</string>
+   </property>
+   <property name="statusTip">
+    <string>Switch to fast view mode (no link parsing)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+V</string>
    </property>
   </action>
   <action name="actionPreferences_SyntaxHighlighting">

--- a/usdmanager/main_window.ui
+++ b/usdmanager/main_window.ui
@@ -1044,7 +1044,7 @@
     <string>&amp;Raw View</string>
    </property>
    <property name="statusTip">
-    <string>Switch to raw view mode (no link parsing)</string>
+    <string>Switch to raw view mode (no link parsing or syntax highlighting)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+V</string>

--- a/usdmanager/main_window.ui
+++ b/usdmanager/main_window.ui
@@ -589,7 +589,7 @@
    <addaction name="separator"/>
    <addaction name="actionBrowse"/>
    <addaction name="actionEdit"/>
-   <addaction name="actionFastView"/>
+   <addaction name="actionRawView"/>
   </widget>
   <widget class="QToolBar" name="navToolbar">
    <property name="windowTitle">
@@ -1034,17 +1034,17 @@
     <string>Ctrl+E</string>
    </property>
   </action>
-  <action name="actionFastView">
+  <action name="actionRawView">
    <property name="icon">
-    <iconset theme="view-refresh">
+    <iconset theme="accessories-text-editor">
      <normaloff/>
     </iconset>
    </property>
    <property name="text">
-    <string>&amp;Fast View</string>
+    <string>&amp;Raw View</string>
    </property>
    <property name="statusTip">
-    <string>Switch to fast view mode (no link parsing)</string>
+    <string>Switch to raw view mode (no link parsing)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+V</string>

--- a/usdmanager/preferences_dialog.py
+++ b/usdmanager/preferences_dialog.py
@@ -60,6 +60,7 @@ class PreferencesDialog(QDialog):
         self.checkBox_parseLinks.setChecked(parent.preferences['parseLinks'])
         self.checkBox_newTab.setChecked(parent.preferences['newTab'])
         self.checkBox_syntaxHighlighting.setChecked(parent.preferences['syntaxHighlighting'])
+        self.checkBox_rawViewDefault.setChecked(parent.preferences['rawViewDefault'])
         self.checkBox_teletypeConversion.setChecked(parent.preferences['teletype'])
         self.checkBox_lineNumbers.setChecked(parent.preferences['lineNumbers'])
         self.checkBox_showAllMessages.setChecked(parent.preferences['showAllMessages'])
@@ -211,6 +212,16 @@ class PreferencesDialog(QDialog):
             `bool`
         """
         return self.checkBox_syntaxHighlighting.isChecked()
+
+    def getPrefRawViewDefault(self):
+        """ Get the user preference for Raw View mode as default.
+
+        :Returns:
+            State of "Default to Raw View mode" check box.
+        :Rtype:
+            `bool`
+        """
+        return self.checkBox_rawViewDefault.isChecked()
 
     def getPrefTeletypeConversion(self):
         """ Get the user preference to enable teletype character conversion.

--- a/usdmanager/preferences_dialog.ui
+++ b/usdmanager/preferences_dialog.ui
@@ -430,6 +430,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="checkBox_rawViewDefault">
+         <property name="toolTip">
+          <string>Start new tabs in Raw View mode by default for better performance with large files</string>
+         </property>
+         <property name="text">
+          <string>Default to Raw View mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QFormLayout" name="formLayout_2">
          <item row="0" column="0">
           <widget class="QLabel" name="labelLineLimit">
@@ -524,6 +534,7 @@
   <tabstop>checkBox_teletypeConversion</tabstop>
   <tabstop>checkBox_syntaxHighlighting</tabstop>
   <tabstop>checkBox_parseLinks</tabstop>
+  <tabstop>checkBox_rawViewDefault</tabstop>
   <tabstop>lineLimitSpinBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>


### PR DESCRIPTION
- Add Fast View toggle (Ctrl+Shift+V) that disables link parsing
- Skips expensive file path resolution and HTML link generation
- Maintains read-only browser interface without edit mode restrictions
- Add fastViewDefault preference setting for new tabs
- Update parser stop logic to include fast view mode

This addresses performance issues when opening very large USD files by providing a quick view option that bypasses visual helpers while maintaining the familiar browse interface.